### PR TITLE
Vcf check feature

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: GWASTools
-Version: 1.25.0
+Version: 1.25.2
 Type: Package
 Title: Tools for Genome Wide Association Studies
 Description: Classes for storing very large GWAS data sets and annotation, and functions for GWAS data cleaning and analysis.

--- a/R/vcfWrite.R
+++ b/R/vcfWrite.R
@@ -244,7 +244,7 @@ vcfCheck <- function(genoData, vcf.file, sample.col="scanID", id.col="snpID",
         geno.vcf <- matrix(x, ncol=ncol, byrow=TRUE)
         id <- geno.vcf[,3]
         ref.vcf <- geno.vcf[,4]
-        geno.vcf <- geno.vcf[,10:ncol]
+        geno.vcf <- geno.vcf[, 10:ncol, drop=FALSE]
 
         ## create df of VCF snp ID and ref allele to facilitate
         ## subsequent subsetting of ref allele to match checked SNPs
@@ -283,7 +283,7 @@ vcfCheck <- function(genoData, vcf.file, sample.col="scanID", id.col="snpID",
 
         ## subset block to snps and samples to be checked, i.e.
         ## those overlapping with genoData and not in exclude lists
-        geno.vcf <- geno.vcf[snp.block.incl, samp.vcf.incl]
+        geno.vcf <- geno.vcf[snp.block.incl, samp.vcf.incl, drop=FALSE]
 
         ## only continue if there are snps left to check after exclusions
         if(nrow(geno.vcf) > 0) {

--- a/R/vcfWrite.R
+++ b/R/vcfWrite.R
@@ -216,7 +216,7 @@ vcfCheck <- function(genoData, vcf.file, sample.col="scanID", id.col="snpID",
     vcf.samp.only <- setdiff(samp.allvcf, samp.id.dat[,sample.col])
     if(length(vcf.samp.only) > 0){
       message("Note VCF has ", prettyNum(length(vcf.samp.only), big.mark=","),
-              " sample(s) not present in genoData;\n these will be excluded from the check")
+              " sample(s) not present in genoData;\nthese will be excluded from the check")
     }
 
     ## check if VCF includes more genoData samps than are retained
@@ -234,8 +234,9 @@ vcfCheck <- function(genoData, vcf.file, sample.col="scanID", id.col="snpID",
                                  with(samp.id.dat, samp.id.dat[vcf & include, sample.col])]
     
     ## check if samples are in same order - give warning in diff order
-    if(!allequal(samp.vcf.incl, samp.id.dat[samp.id.dat$include, sample.col])) {
-      warning("Note, sample order in VCF differs from genoData")
+    if(!allequal(as.character(samp.vcf.incl),
+                 as.character(samp.id.dat[samp.id.dat$include, sample.col]))) {
+      message("Note, sample order in VCF differs from genoData")
     }
 
     ## reads VCF file block.size lines at a time
@@ -268,7 +269,7 @@ vcfCheck <- function(genoData, vcf.file, sample.col="scanID", id.col="snpID",
         vcf.snp.only <- setdiff(id, snp.id.dat[,id.col])
         if(length(vcf.snp.only) > 0 & verbose) {
             message("Note VCF block has ", prettyNum(length(vcf.snp.only), big.mark=","),
-              " SNP(s) not present in genoData;\n these will be excluded from the check")
+              " SNP(s) not present in genoData;\nthese will be excluded from the check")
         }
 
         ## get vector of snps to check

--- a/R/vcfWrite.R
+++ b/R/vcfWrite.R
@@ -303,9 +303,10 @@ vcfCheck <- function(genoData, vcf.file, sample.col="scanID", id.col="snpID",
 
             ## get list of snpIDs to check in this block
             ## could this be done by matching snp.id.dat to geno.vcf rownames?
+            ## yes, but coerce to character so it's not used as index
             snp.block.sel <- snp.id.dat[, id.col] %in% snp.block.include
             snpID.block.include <- snp.id.dat[snp.block.sel, "snpID"]
-x
+
             ## get VCF ref allele for snps in this block
             ref.block <- ref.dat$ref[match(snp.block.include, ref.dat$var)]
 

--- a/R/vcfWrite.R
+++ b/R/vcfWrite.R
@@ -305,8 +305,10 @@ vcfCheck <- function(genoData, vcf.file, sample.col="scanID", id.col="snpID",
             ## compare alleleA and identify switches (i.e., diff allele being counted)
             ref.orig <- alleleA[match(rownames(geno.vcf), snp.id.dat[, id.col])]
             allele.switch <- ref.orig != ref.block
-            ## convert to count same allele, where alleleA/REF differs
-            geno.orig[allele.switch,] <- 2 - geno.orig[allele.switch,]
+            if(sum(allele.switch) > 0) {
+              ## convert to count same allele, where alleleA/REF differs
+              geno.orig[allele.switch,] <- 2 - geno.orig[allele.switch,]
+             }
 
             ## now we have matrices of all genos,
             ## made to be in same order snp and sample-wise

--- a/inst/unitTests/vcfWrite_test.R
+++ b/inst/unitTests/vcfWrite_test.R
@@ -74,6 +74,7 @@ test_setInfo <- function() {
                       alleleB=rep("G", nsnp),
                       stringsAsFactors=FALSE)
     samp <- data.frame(scanID=1:nsamp)
+
     mgr <- MatrixGenotypeReader(matrix(2, nrow=nsnp, ncol=nsamp),
                                 snpID=snp$snpID,
                                 chromosome=snp$chromosome,
@@ -111,10 +112,18 @@ test_snp.exclude <- function() {
     newfile <- tempfile()
     vcfWrite(genoData, newfile, snp.exclude=c(2,4))
     vcf <- readVcf(newfile, "hg18")
-    checkIdentical(geno(vcf)$GT, matrix("0/0", nrow=3, ncol=3, dimnames=list(c(1,3,5), 1:3)))
-    unlink(newfile)
+    checkIdentical(geno(vcf)$GT, matrix("0/0", nrow=3, ncol=3,
+                                        dimnames=list(c(1,3,5), 1:3)))
 
-    # add vcfCheck
+    # check snp exclusion argument of vcfCheck
+    msg <- capture.output(vcfCheck(genoData, newfile, snp.exclude=c(2,4)),
+                          type="message")
+
+    # check for expected messages
+    checkIdentical("Excluding 2 genoData SNPs from check", msg[1])
+    checkIdentical("Checked 3 SNPs", msg[2])
+    
+    unlink(newfile)    
 }
 
 test_both.exclude <- function() {
@@ -123,7 +132,19 @@ test_both.exclude <- function() {
     newfile <- tempfile()
     vcfWrite(genoData, newfile, scan.exclude=1, snp.exclude=1)
     vcf <- readVcf(newfile, "hg18")
-    checkIdentical(geno(vcf)$GT, matrix("0/0", nrow=3, ncol=3, dimnames=list(2:4, 2:4)))
+    checkIdentical(geno(vcf)$GT, matrix("0/0", nrow=3, ncol=3,
+                                        dimnames=list(2:4, 2:4)))
+
+    # check exclusion arguments of vcfCheck
+    msg <- capture.output(vcfCheck(genoData, newfile,
+                                   scan.exclude=1, snp.exclude=1),
+                          type="message")
+    
+    # check for expected messages
+    checkIdentical("Excluding 1 genoData samples from check", msg[1])
+    checkIdentical("Excluding 1 genoData SNPs from check", msg[2])    
+    checkIdentical("Checked 3 SNPs", msg[3])
+    
     unlink(newfile)
 }
 
@@ -157,6 +178,16 @@ test_scan.order <- function() {
     vcfWrite(genoData, newfile, scan.order=5:1, scan.exclude=2)
     vcf <- readVcf(newfile, "hg18")
     checkIdentical(colnames(vcf), as.character(c(5,4,3,1)))
+
+    # check vcfCheck message for different scan order
+    msg <- capture.output(vcfCheck(genoData, newfile, scan.exclude=2),
+                          type="message")
+
+    # check for expected messages
+    checkIdentical("Excluding 1 genoData samples from check", msg[1])
+    checkIdentical("Note, sample order in VCF differs from genoData", msg[2])    
+    checkIdentical("Checked 3 SNPs", msg[3])    
+
     unlink(newfile)
 }
 
@@ -170,17 +201,27 @@ test_ref.allele <- function() {
     checkIdentical(as.character(ref(vcf)), rep("A", 3))
     checkIdentical(as.character(unlist(alt(vcf))), rep("G", 3))
 
+    msg <- capture.output(vcfCheck(genoData, newfile), type="message")
+    checkIdentical("Checked 3 SNPs", msg)
+
     vcfWrite(genoData, newfile, ref=rep("B", 3))
     vcf <- readVcf(newfile, "hg18")
     checkIdentical(geno(vcf)$GT, matrix("1/1", nrow=3, ncol=2, dimnames=list(1:3, 1:2)))
     checkIdentical(as.character(ref(vcf)), rep("G", 3))
     checkIdentical(as.character(unlist(alt(vcf))), rep("A", 3))
 
+    msg <- capture.output(vcfCheck(genoData, newfile), type="message")
+    checkIdentical("Checked 3 SNPs", msg)
+    
     vcfWrite(genoData, newfile, ref=c("A","B","A"))
     vcf <- readVcf(newfile, "hg18")
     checkIdentical(geno(vcf)$GT, matrix(c("0/0", "1/1", "0/0"), nrow=3, ncol=2, dimnames=list(1:3, 1:2)))
     checkIdentical(as.character(ref(vcf)), c("A","G","A"))
     checkIdentical(as.character(unlist(alt(vcf))), c("G","A","G"))
+
+    msg <- capture.output(vcfCheck(genoData, newfile), type="message")
+    checkIdentical("Checked 3 SNPs", msg)    
+    
     unlink(newfile)
 }
 
@@ -261,10 +302,95 @@ test_vcfCheck_subset <- function() {
     genoData <- .testGenoData(5,5)
     newfile <- tempfile()
     vcfWrite(genoData, newfile, snp.exclude=c(2,4), scan.order=c(4,3,5,1))
-    vcfCheck(genoData, newfile)
+    vcfCheck(genoData, newfile, snp.exclude=c(2,4), scan.exclude=2)
     unlink(newfile)
 }
 
-# add vcfCheck test where genotype is perturbed - should actually be diff
-# make sure i'm checking for snp and scan order diffs
-# check for msgs when VCF has more data than genoData
+# vcfCheck test where genotype is perturbed - actually different
+
+test_vcfCheck_discrepant <- function() {
+    genoData <- .testGenoData(5,3)
+    newfile <- tempfile()
+    vcfWrite(genoData, newfile)
+
+    # change genotypes in genoData
+    geno.diff <- getGenotypeSelection(genoData, snp=1:5, scan=1:3)
+    geno.diff[2:2] <- 1
+
+    diffMatx <- MatrixGenotypeReader(genotype=geno.diff,
+                                     snpID=1:5, scanID=1:3,
+                                     chromosome=getChromosome(genoData),
+                                     position=getPosition(genoData))
+
+    genoDiff <- GenotypeData(diffMatx, scanAnnot=getScanAnnotation(genoData),
+                             snpAnnot=getSnpAnnotation(genoData))
+
+    # confirm vcfCheck generates an error
+    checkException(vcfCheck(genoDiff, newfile), silent=TRUE)
+
+    # check error message
+    msg <- geterrmessage()
+    checkIdentical("Error in vcfCheck(genoDiff, newfile) : \n  genoData and VCF are not equal, starting at VCF variant ID 2\n", msg)
+
+    unlink(newfile)
+
+}
+
+# check for msgs when VCF has more samples than genoData
+test_vcfCheck_extSamps <- function() {
+    genoData <- .testGenoData(5,5)
+    newfile <- tempfile()
+    vcfWrite(genoData, newfile)
+
+    # subset genoData
+    geno.mini <- getGenotypeSelection(genoData, snp=1:5, scan=1:3)
+
+    miniMatx <- MatrixGenotypeReader(genotype=geno.mini,
+                                     snpID=1:5, scanID=1:3,
+                                     chromosome=getChromosome(genoData),
+                                     position=getPosition(genoData))
+
+    # subset scan annot
+    scanAnnot <- getScanAnnotation(genoData)
+    scanMini <- scanAnnot[getScanID(scanAnnot) %in% 1:3,]
+
+    genoMini <- GenotypeData(miniMatx, scanAnnot=scanMini,
+                             snpAnnot=getSnpAnnotation(genoData))
+
+    msg <- capture.output(vcfCheck(genoMini, newfile), type="message")
+    checkIdentical("Note VCF has 2 sample(s) not present in genoData;", msg[1])
+    checkIdentical("these will be excluded from the check", msg[2])
+    checkIdentical("Checked 5 SNPs", msg[3])
+
+    unlink(newfile)
+}
+
+# check for msgs when VCF has more snps than genoData
+test_vcfCheck_extSamps <- function() {
+    genoData <- .testGenoData(5,5)
+    newfile <- tempfile()
+    vcfWrite(genoData, newfile)
+
+    # subset genoData
+    geno.mini <- getGenotypeSelection(genoData, snp=1:3, scan=1:5)
+
+    miniMatx <- MatrixGenotypeReader(genotype=geno.mini,
+                                     snpID=1:3, scanID=1:5,
+                                     chromosome=getChromosome(genoData)[1:3],
+                                     position=getPosition(genoData)[1:3])
+
+    # subset np annot
+    snpAnnot <- getSnpAnnotation(genoData)
+    snpMini <- snpAnnot[getSnpID(snpAnnot) %in% 1:3,]
+
+    genoMini <- GenotypeData(miniMatx, scanAnnot=getScanAnnotation(genoData),
+                             snpAnnot=snpMini)
+
+    msg <- capture.output(vcfCheck(genoMini, newfile), type="message")
+    checkIdentical("Note VCF block has 2 SNP(s) not present in genoData;", msg[1])
+    checkIdentical("these will be excluded from the check", msg[2])
+    checkIdentical("Note after applying exclude argument, VCF block contains additional genoData SNPs", msg[3])
+    checkIdentical("Checked 3 SNPs", msg[4])
+
+    unlink(newfile)
+}

--- a/inst/unitTests/vcfWrite_test.R
+++ b/inst/unitTests/vcfWrite_test.R
@@ -94,7 +94,10 @@ test_scan.exclude <- function() {
     checkIdentical(geno(vcf)$GT, matrix("0/0", nrow=3, ncol=3, dimnames=list(1:3, c(1,3,5))))
 
     # check scan exclusion argument of vcfCheck
-    vcfCheck(genoData, newfile, scan.exclude=c(2,4), block.size=1)
+    vcfCheck(genoData, newfile, scan.exclude=c(2,4), block.size=2)
+
+    #### SN, 12/15/17
+    # getting Error in geno.orig[allele.switch, ] : incorrect number of dimensions -- need to debug
     
     unlink(newfile)
 

--- a/inst/unitTests/vcfWrite_test.R
+++ b/inst/unitTests/vcfWrite_test.R
@@ -91,6 +91,10 @@ test_scan.exclude <- function() {
     vcf <- readVcf(newfile, "hg18")
     checkIdentical(geno(vcf)$GT, matrix("0/0", nrow=3, ncol=3, dimnames=list(1:3, c(1,3,5))))
     unlink(newfile)
+
+    # add vcfCheck test for scan include
+    # can check whether function gives error
+    # also check for epxeted msgs: capture.output, type=message
 }
 
 test_snp.exclude <- function() {
@@ -101,6 +105,8 @@ test_snp.exclude <- function() {
     vcf <- readVcf(newfile, "hg18")
     checkIdentical(geno(vcf)$GT, matrix("0/0", nrow=3, ncol=3, dimnames=list(c(1,3,5), 1:3)))
     unlink(newfile)
+
+    # add vcfCheck
 }
 
 test_both.exclude <- function() {
@@ -250,3 +256,7 @@ test_vcfCheck_subset <- function() {
     vcfCheck(genoData, newfile)
     unlink(newfile)
 }
+
+# add vcfCheck test where genotype is perturbed - should actually be diff
+# make sure i'm checking for snp and scan order diffs
+# check for msgs when VCF has more data than genoData

--- a/inst/unitTests/vcfWrite_test.R
+++ b/inst/unitTests/vcfWrite_test.R
@@ -91,19 +91,18 @@ test_scan.exclude <- function() {
     # write out VCF excluding scanIDs 2 and 4
     vcfWrite(genoData, newfile, scan.exclude=c(2,4))
     vcf <- readVcf(newfile, "hg18")
-    checkIdentical(geno(vcf)$GT, matrix("0/0", nrow=3, ncol=3, dimnames=list(1:3, c(1,3,5))))
+    checkIdentical(geno(vcf)$GT, matrix("0/0", nrow=3, ncol=3,
+                                        dimnames=list(1:3, c(1,3,5))))
 
     # check scan exclusion argument of vcfCheck
-    vcfCheck(genoData, newfile, scan.exclude=c(2,4), block.size=2)
+    msg <- capture.output(vcfCheck(genoData, newfile, scan.exclude=c(2,4)),
+                          type="message")
 
-    #### SN, 12/15/17
-    # getting Error in geno.orig[allele.switch, ] : incorrect number of dimensions -- need to debug
+    # check for expected messages
+    checkIdentical("Excluding 2 genoData samples from check", msg[1])
+    checkIdentical("Checked 3 SNPs", msg[2])    
     
     unlink(newfile)
-
-    # add vcfCheck test for scan include
-    # can check whether function gives error
-    # also check for expected msgs: capture.output, type=message
 }
 
 test_snp.exclude <- function() {

--- a/inst/unitTests/vcfWrite_test.R
+++ b/inst/unitTests/vcfWrite_test.R
@@ -85,16 +85,22 @@ test_setInfo <- function() {
 
 test_scan.exclude <- function() {
     require(VariantAnnotation)
+    # make test genoData with 3 snps, 5 scans
     genoData <- .testGenoData(3,5)
     newfile <- tempfile()
+    # write out VCF excluding scanIDs 2 and 4
     vcfWrite(genoData, newfile, scan.exclude=c(2,4))
     vcf <- readVcf(newfile, "hg18")
     checkIdentical(geno(vcf)$GT, matrix("0/0", nrow=3, ncol=3, dimnames=list(1:3, c(1,3,5))))
+
+    # check scan exclusion argument of vcfCheck
+    vcfCheck(genoData, newfile, scan.exclude=c(2,4), block.size=1)
+    
     unlink(newfile)
 
     # add vcfCheck test for scan include
     # can check whether function gives error
-    # also check for epxeted msgs: capture.output, type=message
+    # also check for expected msgs: capture.output, type=message
 }
 
 test_snp.exclude <- function() {

--- a/man/vcfWrite.Rd
+++ b/man/vcfWrite.Rd
@@ -26,7 +26,7 @@ vcfWrite(genoData, vcf.file="out.vcf", sample.col="scanID",
 
 vcfCheck(genoData, vcf.file,
          sample.col="scanID", id.col="snpID",
-         scan.exclude=NULL, snp.exclude=NULL
+         scan.exclude=NULL, snp.exclude=NULL,
          block.size=1000, verbose=TRUE)
 }
 \arguments{

--- a/man/vcfWrite.Rd
+++ b/man/vcfWrite.Rd
@@ -8,6 +8,10 @@
 
 \code{vcfWrite} writes a VCF file from a \code{\link{GenotypeData}}
 object.
+
+\code{vcfCheck} compares the genotypes in a VCF file to
+the corresponding genotypes in \code{genoData}.
+
 }
 \usage{
 genoDataAsVCF(genoData, sample.col="scanID",
@@ -20,8 +24,10 @@ vcfWrite(genoData, vcf.file="out.vcf", sample.col="scanID",
          info.cols=NULL, scan.exclude=NULL, snp.exclude=NULL,
          scan.order=NULL, ref.allele=NULL, block.size=1000, verbose=TRUE)
 
-vcfCheck(genoData, vcf.file, sample.col="scanID",
-         id.col="snpID", block.size=1000, verbose=TRUE)
+vcfCheck(genoData, vcf.file,
+         sample.col="scanID", id.col="snpID",
+         scan.exclude=NULL, snp.exclude=NULL
+         block.size=1000, verbose=TRUE)
 }
 \arguments{
   \item{genoData}{A \code{\link{GenotypeData}} object with scan and SNP annotation.}
@@ -31,8 +37,10 @@ vcfCheck(genoData, vcf.file, sample.col="scanID",
   \item{qual.col}{name of the column in the SNP annotation to use as "QUAL" column in the VCF file}
   \item{filter.cols}{vector of column names in the SNP annotation to use as "FILTER" column in the VCF file.  These columns should be logical vectors, with \code{TRUE} for SNPs to be filtered.  Any SNPs with a value of \code{FALSE} for all filter columns will be set to "PASS".}
   \item{info.cols}{vector of column names in the SNP annotation to concatenate for the "INFO" column in the VCF file.}
-  \item{scan.exclude}{vector of scanIDs to exclude from VCF file}
-  \item{snp.exclude}{vector of snpIDs to exclude from VCF file}
+  \item{scan.exclude}{vector of scanIDs to exclude from creation or
+         checking of VCF file}
+  \item{snp.exclude}{vector of snpIDs to exclude from creation or
+         checking of VCF file}
   \item{scan.order}{vector of scanIDs to include in VCF file, in the order in which they should be written}
   \item{ref.allele}{vector of "A" or "B" values indicating where allele A or allele B should be the reference allele for each SNP.  Default is to use allele A as the reference allele.}
   \item{block.size}{Number of SNPs to read from \code{genoData} at a
@@ -42,7 +50,16 @@ vcfCheck(genoData, vcf.file, sample.col="scanID",
 \details{
 	REF will be alleleA and ALT will be alleleB.
 
-	vcfCheck compares the genotypes (diploid only) in a VCF file to the corresponding genotypes in \code{genoData}.  It stops with an error when it detects a discordant genotype.  It assumes that the "ID" column of the VCF file has unique values that can be matched with a column in the SNP annotation, and that all SNPs in the VCF file are present in \code{genoData}.
+	vcfCheck compares the genotypes (diploid only) in a VCF file to
+	the corresponding genotypes in \code{genoData}.  It stops with
+	an error when it detects a discordant genotype.  It assumes that
+	the "ID" column of the VCF file has unique values that can be
+	matched with a column in the SNP annotation. The VCF file may
+	contain additional samples or SNPs not present in the
+	\code{genoData}; these records will be automaticlaly excluded from the check.
+	Users may exclude additional SNPs and samples (i.e. those
+	overlapping with \code{genoData}) using the \code{scan.exclude}
+	and \code{snp.exclude} arguments.
 }
 \references{
 	The variant call format and VCFtools.
@@ -50,7 +67,7 @@ vcfCheck(genoData, vcf.file, sample.col="scanID",
 	Lunter G, Marth GT, Sherry ST, McVean G, Durbin R; 1000 Genomes Project Analysis Group.
 	Bioinformatics. 2011 Aug 1;27(15):2156-8. Epub 2011 Jun 7.
 }
-\author{Stephanie Gogarten, Michael Lawrence}
+\author{Stephanie Gogarten, Michael Lawrence, Sarah Nelson}
 \seealso{\code{\link[SNPRelate]{snpgdsVCF2GDS}}}
 \examples{
 library(GWASdata)


### PR DESCRIPTION
Hi Stephanie, 
I have edited vcfCheck to 
- allow snp and sample exclude lists
- give more informative messages when vcf data differs from genoData (extra samps or snps, diff samp order)
- give more informative error message when a discrepancy is found

I expanded the unit tests accordingly and incremented the package version number to 1.25.2. 

If all looks good, please merge this feature branch into your master.

Thanks!
~Sarah